### PR TITLE
feat: add TUI history tab 

### DIFF
--- a/cmd/tx-disguise/main.go
+++ b/cmd/tx-disguise/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 const defaultFuturesCode = "TXF"
-const version = "beta-0.1.1"
+const version = "v0.2.0-beta"
 
 func usage() {
 	fmt.Println(`

--- a/cmd/tx-disguise/main.go
+++ b/cmd/tx-disguise/main.go
@@ -13,14 +13,14 @@ const version = "beta-0.1.1"
 
 func usage() {
 	fmt.Println(`
-	Usage: tx-disguise [-v] [-h] [ -y | -z ]
+	Usage: txd [-v] [-h] [ -y | -z ]
 		-v: show version  
 		-h: show this help
 	Symbol Options:
 		-y: 小台 (MXF)  
 		-z: 微台 (TMF)
 	Example: 
-		tx-disguise -y
+		txd -y
 	`)
 }
 

--- a/internal/shared/ringbuffer.go
+++ b/internal/shared/ringbuffer.go
@@ -1,0 +1,91 @@
+package shared
+
+import (
+	"errors"
+	"sync"
+)
+
+type RingBuffer[T any] struct {
+	buffer []T
+	size   int
+	start  int
+	end    int
+	full   bool
+	mu     sync.Mutex
+}
+
+func NewRingBuffer[T any](capacity int) *RingBuffer[T] {
+	return &RingBuffer[T]{
+		buffer: make([]T, capacity),
+		size:   capacity,
+	}
+}
+
+// Push 寫入一筆資料，滿了會覆蓋最舊資料
+func (r *RingBuffer[T]) Push(value T) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.buffer[r.end] = value
+	r.end = (r.end + 1) % r.size
+
+	if r.full {
+		r.start = (r.start + 1) % r.size
+	} else if r.end == r.start {
+		r.full = true
+	}
+}
+
+// Pop 取出最舊資料
+func (r *RingBuffer[T]) Pop() (T, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var zero T
+	if r.IsEmpty() {
+		return zero, errors.New("buffer is empty")
+	}
+	val := r.buffer[r.start]
+	r.buffer[r.start] = zero // 清除被取出的資料
+	r.start = (r.start + 1) % r.size
+	r.full = false
+	return val, nil
+}
+
+// GetAll 回傳所有元素（依照順序）
+func (r *RingBuffer[T]) GetAll() []T {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var out []T
+	if r.IsEmpty() {
+		return out
+	}
+
+	var count int
+	if r.full {
+		count = r.size
+	} else if r.end >= r.start {
+		count = r.end - r.start
+	} else {
+		count = r.size - r.start + r.end
+	}
+
+	for i := 0; i < count; i++ {
+		idx := (r.start + i) % r.size
+		out = append(out, r.buffer[idx])
+	}
+	return out
+}
+
+func (r *RingBuffer[T]) IsEmpty() bool {
+	return !r.full && r.start == r.end
+}
+
+func (r *RingBuffer[T]) IsFull() bool {
+	return r.full
+}
+
+func (r *RingBuffer[T]) Capacity() int {
+	return r.size
+}

--- a/internal/shared/ringbuffer_test.go
+++ b/internal/shared/ringbuffer_test.go
@@ -1,0 +1,79 @@
+package shared
+
+import (
+	"testing"
+)
+
+func TestRingBuffer_PushPop(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	// Test empty buffer
+	if !rb.IsEmpty() {
+		t.Error("Buffer should be empty initially")
+	}
+
+	// Push elements
+	rb.Push(1)
+	rb.Push(2)
+	if rb.IsEmpty() {
+		t.Error("Buffer should not be empty after push")
+	}
+
+	// Pop elements
+	v, err := rb.Pop()
+	if err != nil || v != 1 {
+		t.Errorf("Expected 1, got %v, err: %v", v, err)
+	}
+	v, err = rb.Pop()
+	if err != nil || v != 2 {
+		t.Errorf("Expected 2, got %v, err: %v", v, err)
+	}
+
+	// Pop from empty
+	_, err = rb.Pop()
+	if err == nil {
+		t.Error("Expected error when popping from empty buffer")
+	}
+}
+
+func TestRingBuffer_Overwrite(t *testing.T) {
+	rb := NewRingBuffer[int](2)
+	rb.Push(1)
+	rb.Push(2)
+	if !rb.IsFull() {
+		t.Error("Buffer should be full")
+	}
+	// Overwrite oldest
+	rb.Push(3)
+	if !rb.IsFull() {
+		t.Error("Buffer should still be full after overwrite")
+	}
+	vals := rb.GetAll()
+	if len(vals) != 2 || vals[0] != 2 || vals[1] != 3 {
+		t.Errorf("Expected [2 3], got %v", vals)
+	}
+}
+
+func TestRingBuffer_GetAll(t *testing.T) {
+	rb := NewRingBuffer[string](3)
+	rb.Push("a")
+	rb.Push("b")
+	vals := rb.GetAll()
+	if len(vals) != 2 || vals[0] != "a" || vals[1] != "b" {
+		t.Errorf("Expected [a b], got %v", vals)
+	}
+
+	rb.Push("c")
+	rb.Push("d") // Overwrites "a"
+	vals = rb.GetAll()
+	if len(vals) != 3 || vals[0] != "b" || vals[1] != "c" || vals[2] != "d" {
+		t.Errorf("Expected [b c d], got %v", vals)
+	}
+}
+
+func TestRingBuffer_Capacity(t *testing.T) {
+	rb := NewRingBuffer[float64](5)
+	if rb.Capacity() != 5 {
+		t.Errorf("Expected capacity 5, got %d", rb.Capacity())
+	}
+}

--- a/internal/tui/teaui.go
+++ b/internal/tui/teaui.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 	"tx-disguise/internal/futures"
+	"tx-disguise/internal/shared"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/term"
@@ -16,11 +17,16 @@ type model struct {
 	futuresService futures.IService
 	fakeInfo       []string
 	futures        string
+	futuresHistory *shared.RingBuffer[string]
+	height         int
+	currentTab     int // 0: fakeInfo, 1: futuresHistory
+	historyScroll  int // scroll position for futuresHistory
 }
 
 type (
-	fakeInfoMsg []string
-	futuresMsg  string
+	fakeInfoMsg       []string
+	futuresMsg        string
+	futuresHistoryMsg *shared.RingBuffer[string]
 )
 
 func genFakeInfoMsg() []string {
@@ -37,7 +43,7 @@ func genFakeInfoMsg() []string {
 				headerIdx = i
 				continue
 			} else {
-				return lines[i-1:]
+				return lines[i:]
 			}
 		}
 	}
@@ -52,7 +58,7 @@ func (m model) fakeInfoTicker() tea.Cmd {
 
 func (m model) futuresTicker() tea.Cmd {
 	return tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
-		return futuresMsg(fmt.Sprintf("[%s] %-21s | %-21s \n",
+		return futuresMsg(fmt.Sprintf("[%s] %-21s | %-21s ",
 			time.Now().Format("01/02 15:04:05"),
 			m.futuresService.GetCurrentFuturesPrice(),
 			m.futuresService.GetCurrentActualPrice(),
@@ -60,8 +66,15 @@ func (m model) futuresTicker() tea.Cmd {
 	})
 }
 
+func (m model) futuresHistoryTicker() tea.Cmd {
+	return tea.Tick(1*time.Minute, func(t time.Time) tea.Msg {
+		m.futuresHistory.Push(m.futures)
+		return futuresHistoryMsg(m.futuresHistory)
+	})
+}
+
 func (m model) Init() tea.Cmd {
-	return tea.Batch(m.fakeInfoTicker(), m.futuresTicker())
+	return tea.Batch(m.fakeInfoTicker(), m.futuresTicker(), m.futuresHistoryTicker())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -74,41 +87,89 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.futures = string(msg)
 		return m, m.futuresTicker()
 
+	case futuresHistoryMsg:
+		m.futuresHistory = msg
+		return m, m.futuresHistoryTicker()
+
 	case tea.KeyMsg:
-		if msg.String() == "q" {
+		switch msg.String() {
+		case "q":
 			return m, tea.Quit
+		case "tab":
+			m.currentTab = (m.currentTab + 1) % 2
+			return m, nil
+		case "up":
+			if m.currentTab == 1 {
+				history := m.futuresHistory.GetAll()
+				maxScroll := max(len(history)-max(m.height-3, 0), 0)
+				if m.historyScroll < maxScroll {
+					m.historyScroll++
+				}
+			}
+			return m, nil
+		case "down":
+			if m.currentTab == 1 && m.historyScroll > 0 {
+				m.historyScroll--
+			}
+			return m, nil
 		}
 	}
-
 	return m, nil
 }
 
 func (m model) View() string {
+	if m.currentTab == 0 {
+		if len(m.fakeInfo) == 0 {
+			m.fakeInfo = genFakeInfoMsg()
+		}
+		visibleTopLines := max(m.height-3, 0)
+		fakeBlock := strings.Join(m.fakeInfo[:visibleTopLines], "\n")
+		priceLine := fmt.Sprintf("%s %-11s %-21s | %-21s \n%s", "date", "", "Futures", "Actuals", m.futures)
+		return fmt.Sprintf("%s\n%s\n[q] quit, [tab] switch", fakeBlock, priceLine)
+	}
+	// futuresHistory view
+	history := m.futuresHistory.GetAll()
+	visibleLines := max(m.height-6, 0)
+	lines := make([]string, visibleLines)
+	start := max(len(history)-visibleLines-m.historyScroll, 0)
+	end := max(len(history)-m.historyScroll, 0)
+	if end > len(history) {
+		end = len(history)
+	}
+	for i, j := start, 0; i < end && j < visibleLines; i, j = i+1, j+1 {
+		lines[j] = history[i]
+	}
+	if len(history) == 0 && visibleLines > 0 {
+		lines[0] = "(no history)"
+	}
+	header := fmt.Sprintf(
+		"History in 1 hour (%d entries)\n%s %-11s %-21s | %-21s",
+		len(history),
+		"date",
+		"",
+		"Futures",
+		"Actuals",
+	)
+	return fmt.Sprintf("%s\n%s\n%s\n%s\n\n[q] quit, [tab] switch, [up/down] scroll", header, strings.Join(lines, "\n"), "Current:", m.futures)
+}
+
+func NewProgram(futuresService futures.IService) *tea.Program {
 	// Get terminal size
 	// TODO: width will be used in future updates, default to 80
 	_, height, err := term.GetSize(os.Stdout.Fd())
 	if err != nil || height <= 0 {
 		height = 24 // Default terminal size
 	}
-	if len(m.fakeInfo) == 0 {
-		m.fakeInfo = genFakeInfoMsg()
-	}
-	visibleTopLines := max(height-3, 0)
-	fakeBlock := strings.Join(m.fakeInfo[:visibleTopLines], "\n")
-	priceLine := fmt.Sprintf("%s %-11s %-21s | %-21s \n%s", "date", "", "Futures", "Actuals", m.futures)
-
-	return fmt.Sprintf("%s\n%s\n[q] quit", fakeBlock, priceLine)
-}
-
-func NewProgram(futuresService futures.IService) *tea.Program {
 	m := model{
 		futuresService: futuresService,
 		fakeInfo:       []string{},
-		futures: fmt.Sprintf("[%s] %-21s | %-21s \n",
+		futures: fmt.Sprintf("[%s] %-21s | %-21s ",
 			time.Now().Format("01/02 15:04:05"),
 			"-",
 			"-",
 		),
+		height:         height,
+		futuresHistory: shared.NewRingBuffer[string](60),
 	}
 	return tea.NewProgram(m, tea.WithAltScreen(), tea.WithInputTTY())
 }


### PR DESCRIPTION
## Summary

This PR introduces a generic ring buffer implementation, comprehensive unit tests, and significant enhancements to the TUI, including a new history tab. It also refines the CLI usage text.

## Changes

- **Feature:** Add a generic `RingBuffer` implementation in `internal/shared/ringbuffer.go`.
- **Testing:** Add unit tests for the ring buffer in `internal/shared/ringbuffer_test.go`.
- **TUI Enhancement:** 
  - Add a new tab in the TUI for viewing 1-hour futures history with scroll support.
  - Refactor TUI code to support tab switching and history navigation.
- **CLI Improvement:** Update usage text in `cmd/tx-disguise/main.go` for clarity.

## Motivation

- Provide a reusable, thread-safe ring buffer for internal use.
- Improve test coverage and reliability.
- Enhance the user experience in the TUI by allowing users to view and scroll through historical futures data.
- Make CLI usage instructions clearer for end users.

## Testing

- All new and existing unit tests pass.
- Manual testing of the TUI confirms correct tab switching and history display.